### PR TITLE
Add sidebar icons with animated collapse

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 150px;
+  width: 60px;
   height: 100vh;
   background: #333;
   color: #fff;
@@ -19,6 +19,13 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
+  transition: width 0.3s;
+  align-items: center;
+}
+
+.sidebar:hover {
+  width: 150px;
+  align-items: flex-start;
 }
 
 .sidebar button {
@@ -28,13 +35,39 @@
   font-size: 1rem;
   cursor: pointer;
   text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.sidebar button .icon {
+  width: 1.2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.sidebar button .label {
+  overflow: hidden;
+  max-width: 0;
+  opacity: 0;
+  transition: max-width 0.3s, opacity 0.3s;
+}
+
+.sidebar:hover button .label {
+  max-width: 100px;
+  opacity: 1;
 }
 
 .pages {
-  margin-left: 150px;
+  margin-left: 60px;
   height: 100vh;
   overflow-y: auto;
   scroll-snap-type: y mandatory;
+  transition: margin-left 0.3s;
+}
+
+.sidebar:hover ~ .pages {
+  margin-left: 150px;
 }
 
 .page {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,11 @@ import { useRef } from 'react'
 import './App.css'
 
 const sections = [
-  'inicio',
-  'experiencia',
-  'proyectos',
-  'inspiracion',
-  'contacto',
+  { name: 'inicio', icon: '🏠' },
+  { name: 'experiencia', icon: '💼' },
+  { name: 'proyectos', icon: '💻' },
+  { name: 'inspiracion', icon: '💡' },
+  { name: 'contacto', icon: '✉️' },
 ]
 
 function App() {
@@ -19,20 +19,21 @@ function App() {
   return (
     <div className="app">
       <nav className="sidebar">
-        {sections.map((item, idx) => (
-          <button key={item} onClick={() => handleClick(idx)}>
-            {item}
+        {sections.map(({ name, icon }, idx) => (
+          <button key={name} onClick={() => handleClick(idx)}>
+            <span className="icon">{icon}</span>
+            <span className="label">{name}</span>
           </button>
         ))}
       </nav>
       <div className="pages">
-        {sections.map((item, idx) => (
+        {sections.map(({ name }, idx) => (
           <section
-            key={item}
+            key={name}
             ref={(el) => {
               refs.current[idx] = el
             }}
-            id={item}
+            id={name}
             className="page"
           ></section>
         ))}


### PR DESCRIPTION
## Summary
- display icons next to section names
- add collapsible sidebar on hover
- animate sidebar and pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685db01b05808327b97866dad55e4d1d