### PR TITLE
Add contact buttons and improve hero animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,7 +29,8 @@
   align-items: flex-start;
 }
 
-.sidebar button {
+.sidebar button,
+.sidebar a {
   background: transparent;
   border: none;
   color: inherit;
@@ -39,25 +40,36 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  text-decoration: none;
 }
 
-.sidebar button .icon {
+.sidebar button .icon,
+.sidebar a .icon {
   width: 1.2rem;
   display: flex;
   justify-content: center;
   margin-right: 0.5rem;
 }
 
-.sidebar button .label {
+.sidebar button .label,
+.sidebar a .label {
   overflow: hidden;
   max-width: 0;
   opacity: 0;
   transition: max-width 0.3s, opacity 0.3s;
 }
 
-.sidebar:hover button .label {
+.sidebar:hover button .label,
+.sidebar:hover a .label {
   max-width: 100px;
   opacity: 1;
+}
+
+.sidebar-bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,20 @@ function App() {
             <span className="label">{name}</span>
           </button>
         ))}
+        <div className="sidebar-bottom">
+          <a
+            href="https://wa.me/573023350784"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="icon">💬</span>
+            <span className="label">WhatsApp</span>
+          </a>
+          <a href="mailto:juansebastian3g@gmail.com">
+            <span className="icon">📧</span>
+            <span className="label">Correo</span>
+          </a>
+        </div>
       </nav>
       <div className="pages">
         {sections.map(({ name }, idx) => (

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -24,8 +24,7 @@
 }
 
 .tools,
-.code-window,
-.phone {
+.code-window {
   position: absolute;
   inset: 0;
   display: flex;
@@ -71,7 +70,7 @@
   white-space: pre;
   border-right: 2px solid #c7c7c7;
   width: 0;
-  animation: typing 4s steps(40) 2.5s infinite forwards,
+  animation: typing 4s steps(50) 2.5s infinite forwards,
              blink 0.8s step-end infinite;
 }
 
@@ -92,6 +91,9 @@
   border-radius: 20px;
   background: #000;
   box-sizing: border-box;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   animation: phone-anim 12s linear infinite;
 }
 
@@ -106,6 +108,6 @@
 }
 
 @keyframes phone-anim {
-  0%,60% { opacity: 0; transform: translateX(-50%); }
-  65%,100% { opacity: 1; transform: translateX(0); }
+  0%,60% { opacity: 0; transform: translate(-100%, -50%); }
+  65%,100% { opacity: 1; transform: translate(-50%, -50%); }
 }


### PR DESCRIPTION
## Summary
- add bottom contact buttons for WhatsApp and Gmail in sidebar
- style sidebar items to support links
- adjust hero code typing animation and center phone

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685dc2f00e248327a2a5e49b80cf31cf