### PR TITLE
Center sidebar buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,9 +17,7 @@
   color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
   padding: 1rem;
-  justify-content: center;
   transition: width 0.3s;
   align-items: center;
 }
@@ -27,6 +25,19 @@
 .sidebar:hover {
   width: 150px;
   align-items: flex-start;
+}
+
+.sidebar:hover .sidebar-menu {
+  align-items: flex-start;
+}
+
+.sidebar-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
 }
 
 .sidebar button,
@@ -66,10 +77,14 @@
 }
 
 .sidebar-bottom {
-  margin-top: auto;
+  position: absolute;
+  bottom: 1rem;
+  left: 0;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  align-items: center;
 }
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,12 +20,14 @@ function App() {
   return (
     <div className="app">
       <nav className="sidebar">
-        {sections.map(({ name, icon }, idx) => (
-          <button key={name} onClick={() => handleClick(idx)}>
-            <span className="icon">{icon}</span>
-            <span className="label">{name}</span>
-          </button>
-        ))}
+        <div className="sidebar-menu">
+          {sections.map(({ name, icon }, idx) => (
+            <button key={name} onClick={() => handleClick(idx)}>
+              <span className="icon">{icon}</span>
+              <span className="label">{name}</span>
+            </button>
+          ))}
+        </div>
         <div className="sidebar-bottom">
           <a
             href="https://wa.me/573023350784"


### PR DESCRIPTION
## Summary
- keep WhatsApp and email actions absolutely positioned at the bottom of the sidebar
- wrap navigation buttons in `.sidebar-menu` and center them vertically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de0097ef4832781c8223a5b3708fc