### PR TITLE
Fix missing icon library

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import {
   Folder,
   Lightbulb,
   Mail,
-} from 'lucide-react'
+} from './icons.jsx'
 import './App.css'
 import Hero from './components/Hero.jsx'
 

--- a/src/icons.jsx
+++ b/src/icons.jsx
@@ -1,0 +1,19 @@
+export function House() {
+  return <span role="img" aria-label="house">🏠</span>
+}
+
+export function Briefcase() {
+  return <span role="img" aria-label="briefcase">💼</span>
+}
+
+export function Folder() {
+  return <span role="img" aria-label="folder">📁</span>
+}
+
+export function Lightbulb() {
+  return <span role="img" aria-label="lightbulb">💡</span>
+}
+
+export function Mail() {
+  return <span role="img" aria-label="mail">✉️</span>
+}


### PR DESCRIPTION
## Summary
- provide simple emoji-based icons in a new `icons.jsx` module
- use local icons instead of `lucide-react`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685df18e62e88327b41d0e5cbb27a819