### PR TITLE
Add typing animation to hero title and disable snapping

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -96,7 +96,6 @@
   width: calc(100% - 14%);
   height: 100vh;
   overflow-y: auto;
-  scroll-snap-type: y mandatory;
   transition: margin-left 0.3s, width 0.3s;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
@@ -113,7 +112,6 @@
 
 .page {
   height: 100vh;
-  scroll-snap-align: start;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -2,7 +2,6 @@
   display: flex;
   height: 100vh;
   width: 100%;
-  scroll-snap-align: start;
 }
 
 .hero-left,
@@ -16,6 +15,18 @@
 .hero-left h1 {
   max-width: 90%;
   text-align: center;
+}
+
+.hero-title {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.cursor {
+  display: inline-block;
+  width: 1ch;
+  animation: blink 1s step-end infinite;
 }
 
 .hero-right {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import './Hero.css'
 
 const codeExample = [
@@ -7,10 +8,42 @@ const codeExample = [
 ]
 
 function Hero() {
+  const title = "Hi! I'm Sebastian, React / React-Native developer"
+  const [visibleText, setVisibleText] = useState('')
+  const [typed, setTyped] = useState(false)
+
+  useEffect(() => {
+    let i = 0
+    const interval = setInterval(() => {
+      i += 1
+      setVisibleText(title.slice(0, i))
+      if (i >= title.length) {
+        clearInterval(interval)
+        setTyped(true)
+      }
+    }, 50)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (!typed) return
+    const handleScroll = () => {
+      const scrolled = Math.min(window.scrollY, window.innerHeight)
+      const progress = scrolled / window.innerHeight
+      const len = Math.floor(title.length * (1 - progress))
+      setVisibleText(title.slice(0, len))
+    }
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [typed])
+
   return (
     <div className="hero-banner">
       <div className="hero-left">
-        <h1>Hi! I'm Sebastian, React / React-Native developer</h1>
+        <h1 className="hero-title">
+          {visibleText}
+          <span className="cursor" aria-hidden="true">|</span>
+        </h1>
       </div>
       <div className="hero-right">
         <div className="tools" aria-hidden="true">🛠️</div>
@@ -21,7 +54,8 @@ function Hero() {
                 key={idx}
                 className="code-line"
                 style={{
-                  animation: `typing 2s steps(${line.length}) ${idx * 2}s forwards` +
+                  animation:
+                    `typing 2s steps(${line.length}) ${idx * 2}s forwards` +
                     (idx === codeExample.length - 1
                       ? `, blink 0.8s step-end infinite ${idx * 2}s`
                       : ''),


### PR DESCRIPTION
## Summary
- animate the hero title text so it types on load and deletes while scrolling
- allow free scrolling by removing scroll snap styles
- add title/cursor styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df42c9fcc8327a13757dbb75501f8