### PR TITLE
Fix hero banner width and remove scroll text rewind

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -13,7 +13,7 @@
 }
 
 .hero-left h1 {
-  max-width: 90%;
+  max-width: 40%;
   text-align: center;
 }
 

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -10,7 +10,6 @@ const codeExample = [
 function Hero() {
   const title = "Hi! I'm Sebastian, React / React-Native developer"
   const [visibleText, setVisibleText] = useState('')
-  const [typed, setTyped] = useState(false)
 
   useEffect(() => {
     let i = 0
@@ -19,23 +18,10 @@ function Hero() {
       setVisibleText(title.slice(0, i))
       if (i >= title.length) {
         clearInterval(interval)
-        setTyped(true)
       }
     }, 50)
     return () => clearInterval(interval)
   }, [])
-
-  useEffect(() => {
-    if (!typed) return
-    const handleScroll = () => {
-      const scrolled = Math.min(window.scrollY, window.innerHeight)
-      const progress = scrolled / window.innerHeight
-      const len = Math.floor(title.length * (1 - progress))
-      setVisibleText(title.slice(0, len))
-    }
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [typed])
 
   return (
     <div className="hero-banner">


### PR DESCRIPTION
## Summary
- narrow the hero title to 40%
- remove scroll event that erased the hero title while scrolling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685df78ad8388327b8519fc859e0fb9b