### PR TITLE
Adjust hero layout and fade animation

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -6,33 +6,35 @@
 
 .hero-left,
 .hero-right {
-  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.hero-left h1 {
+.hero-left {
+  flex: 0 0 60%;
+  max-width: 60%;
+}
+
+.hero-right {
+  flex: 0 0 40%;
   max-width: 40%;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-left h1 {
+  width: 100%;
   text-align: center;
+  margin: 0;
+  transition: opacity 0.3s;
 }
 
 .hero-title {
   display: inline-block;
-  overflow: hidden;
-  white-space: nowrap;
+  white-space: normal;
 }
 
-.cursor {
-  display: inline-block;
-  width: 1ch;
-  animation: blink 1s step-end infinite;
-}
-
-.hero-right {
-  position: relative;
-  overflow: hidden;
-}
 
 .tools,
 .code-window {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import './Hero.css'
 
 const codeExample = [
@@ -9,26 +9,29 @@ const codeExample = [
 
 function Hero() {
   const title = "Hi! I'm Sebastian, React / React-Native developer"
-  const [visibleText, setVisibleText] = useState('')
+  const titleRef = useRef(null)
 
   useEffect(() => {
-    let i = 0
-    const interval = setInterval(() => {
-      i += 1
-      setVisibleText(title.slice(0, i))
-      if (i >= title.length) {
-        clearInterval(interval)
-      }
-    }, 50)
-    return () => clearInterval(interval)
+    const el = titleRef.current
+    if (!el) return
+
+    const thresholds = Array.from({ length: 101 }, (_, i) => i / 100)
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        el.style.opacity = String(entry.intersectionRatio)
+      },
+      { threshold: thresholds }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
   }, [])
 
   return (
     <div className="hero-banner">
       <div className="hero-left">
-        <h1 className="hero-title">
-          {visibleText}
-          <span className="cursor" aria-hidden="true">|</span>
+        <h1 className="hero-title" ref={titleRef}>
+          {title}
         </h1>
       </div>
       <div className="hero-right">


### PR DESCRIPTION
## Summary
- split Hero layout into a 60/40 row layout
- center the title text
- remove typing effect and fade title on scroll

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa90e5888327ace347f8cd793fbd