### PR TITLE
Add diagonal sweep animation to experience title

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -24,6 +24,47 @@
   margin-bottom: 1rem;
   font-size: 2.5rem;
   text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.experience-title::before,
+.experience-title::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 150%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(
+    60deg,
+    rgba(0, 0, 0, 0) 40%,
+    rgba(0, 0, 0, 0.5) 50%,
+    rgba(0, 0, 0, 0) 60%
+  );
+  transform: skewX(-30deg);
+}
+
+.experience-title::before {
+  animation: sweep-right 3s infinite;
+}
+
+.experience-title::after {
+  animation: sweep-left 3s infinite;
+  animation-delay: 1s;
+}
+
+@keyframes sweep-right {
+  0% { left: -150%; opacity: 1; }
+  33% { left: 100%; opacity: 1; }
+  34%, 100% { left: 100%; opacity: 0; }
+}
+
+@keyframes sweep-left {
+  0% { left: 100%; opacity: 1; }
+  33% { left: -150%; opacity: 1; }
+  34%, 100% { left: -150%; opacity: 0; }
 }
 
 @keyframes fadeInUp {


### PR DESCRIPTION
## Summary
- add infinite sweep animation to the experience page title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e03fd6ecc8327b7e6df3bc8144734