### PR TITLE
Update experience title shadow

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -24,47 +24,30 @@
   margin-bottom: 1rem;
   font-size: 2.5rem;
   text-align: center;
-  position: relative;
-  overflow: hidden;
 }
 
-.experience-title::before,
-.experience-title::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -150%;
-  width: 150%;
-  height: 100%;
-  pointer-events: none;
+.experience-title-text {
+  display: inline-block;
   background: linear-gradient(
     60deg,
-    rgba(0, 0, 0, 0) 40%,
-    rgba(0, 0, 0, 0.5) 50%,
-    rgba(0, 0, 0, 0) 60%
+    #fff 45%,
+    rgba(0, 0, 0, 0.6) 50%,
+    #fff 55%
   );
-  transform: skewX(-30deg);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  background-size: 200% 100%;
+  animation: sweep-shadow 6s linear infinite;
 }
 
-.experience-title::before {
-  animation: sweep-right 3s infinite;
-}
-
-.experience-title::after {
-  animation: sweep-left 3s infinite;
-  animation-delay: 1s;
-}
-
-@keyframes sweep-right {
-  0% { left: -150%; opacity: 1; }
-  33% { left: 100%; opacity: 1; }
-  34%, 100% { left: 100%; opacity: 0; }
-}
-
-@keyframes sweep-left {
-  0% { left: 100%; opacity: 1; }
-  33% { left: -150%; opacity: 1; }
-  34%, 100% { left: -150%; opacity: 0; }
+@keyframes sweep-shadow {
+  from {
+    background-position: 0% 0;
+  }
+  to {
+    background-position: 200% 0;
+  }
 }
 
 @keyframes fadeInUp {

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -4,7 +4,9 @@ function Experience() {
   return (
     <div className="experience-section">
       <div className="experience-wrapper">
-        <h2 className="experience-title">Experiencia</h2>
+        <h2 className="experience-title">
+          <span className="experience-title-text">Experiencia</span>
+        </h2>
         <p>Hola, soy Juan Sebastián Solano Avilés, un desarrollador full-stack de 23 años que lleva más de tres años y medio creando soluciones de punta a punta. Para mí, programar es lo más parecido a tener superpoderes: una forma de convertir ideas en productos que impactan a las personas.</p>
         <p>En mi día a día combino React y React Native (con Redux Toolkit, React Reanimated y módulos nativos) para construir interfaces fluidas y accesibles en web, iOS y Android. He publicado cuatro aplicaciones móviles en ambas plataformas, gestionando todo el ciclo: diseño, desarrollo, pruebas, despliegue y métricas post-lanzamiento.</p>
         <p>En el backend me muevo con Node.js + TypeScript y Python, orquestando microservicios en GCP y Firebase, integrando bases de datos SQL y NoSQL, y automatizando despliegues con contenedores y pipelines CI/CD. También disfruto meter mano en Kotlin, Objective-C y herramientas como Xcode y Android Studio para desarrollar o integrar funcionalidades nativas cuando el rendimiento lo exige.</p>


### PR DESCRIPTION
## Summary
- limit the experience page shadow animation to the text
- wrap the title text in a span
- slow down the shadow sweep effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e04e15a648327a2a626d6aefd21f0