### PR TITLE
Modify experience title animation

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -26,10 +26,16 @@
   text-align: center;
 }
 
+@property --angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 60deg;
+}
+
 .experience-title-text {
   display: inline-block;
   background: linear-gradient(
-    60deg,
+    var(--angle),
     #fff 45%,
     rgba(0, 0, 0, 0.6) 50%,
     #fff 55%
@@ -38,15 +44,25 @@
   background-clip: text;
   color: transparent;
   background-size: 200% 100%;
-  animation: sweep-shadow 6s linear infinite;
+  animation: sweep-shadow 5s linear infinite;
 }
 
 @keyframes sweep-shadow {
-  from {
+  0% {
+    --angle: 60deg;
     background-position: 0% 0;
   }
-  to {
+  50% {
+    --angle: 60deg;
     background-position: 200% 0;
+  }
+  50.0001% {
+    --angle: -60deg;
+    background-position: 200% 0;
+  }
+  100% {
+    --angle: -60deg;
+    background-position: 0% 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- animate `Experience` title left-to-right then right-to-left
- tilt shadow to match direction and run animation slightly faster

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js` due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685e069b6bb8832780958e1797513510