### PR TITLE
Add sticky notes experience section

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -18,6 +18,32 @@
   opacity: 0;
 }
 
+.postics-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.postic {
+  background: #fef3a0;
+  color: #333;
+  padding: 1rem;
+  width: 220px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transform-origin: center;
+}
+
+.postic h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.postic p {
+  margin: 0.25rem 0;
+}
+
 .experience-title {
   margin-top: 0;
   margin-bottom: 1rem;

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,17 +1,81 @@
+import { useMemo } from 'react'
 import './Experience.css'
 
+const notes = [
+  {
+    title: '✨ Quién soy',
+    content: [
+      'Hola, soy Juan Sebastián Solano Avilés, desarrollador full-stack de 23 años. Llevo 3 años y medio convirtiendo ideas en productos reales. Para mí, programar es lo más parecido a tener superpoderes: materializar soluciones que impactan a las personas.',
+    ],
+  },
+  {
+    title: '🖥️ Front-end & Mobile',
+    content: [
+      'React + React Native',
+      'Redux Toolkit, React Reanimated y módulos nativos',
+      '4 apps publicadas en iOS & Android',
+      'Responsabilidades: UI/UX, pruebas, despliegue, métricas post-lanzamiento',
+    ],
+  },
+  {
+    title: '⚙️ Back-end & DevOps',
+    content: [
+      'Node.js + TypeScript y Python para microservicios',
+      'Infraestructura en GCP y Firebase',
+      'Bases de datos SQL y NoSQL',
+      'Automatización con contenedores y CI/CD pipelines',
+    ],
+  },
+  {
+    title: '📱 Código Nativo',
+    content: [
+      'Kotlin y Objective-C',
+      'Herramientas: Xcode & Android Studio',
+      'Desarrollo o integración de módulos nativos cuando el rendimiento lo exige',
+    ],
+  },
+  {
+    title: '🤖 Experimentos en IA',
+    content: [
+      'Modelos locales en LM Studio (p. ej. Gemma 3)',
+      'Whisper + Coqui TTS para procesamiento de voz en tiempo real',
+      'Próximamente verás estos proyectos (visión por computador, chatbots, etc.) en la sección Proyectos',
+    ],
+  },
+  {
+    title: '🌱 Filosofía Personal',
+    content: [
+      'Curiosidad insaciable, obsesión por el detalle y ganas de compartir conocimiento.',
+      'Meta: seguir construyendo productos que enamoren a los usuarios y desafíen mis límites como desarrollador y como ser humano.',
+    ],
+  },
+]
+
 function Experience() {
+  const rotations = useMemo(() =>
+    notes.map(() => Math.random() * 30 - 15),
+  [])
+
   return (
     <div className="experience-section">
       <div className="experience-wrapper">
         <h2 className="experience-title">
           <span className="experience-title-text">Experiencia</span>
         </h2>
-        <p>Hola, soy Juan Sebastián Solano Avilés, un desarrollador full-stack de 23 años que lleva más de tres años y medio creando soluciones de punta a punta. Para mí, programar es lo más parecido a tener superpoderes: una forma de convertir ideas en productos que impactan a las personas.</p>
-        <p>En mi día a día combino React y React Native (con Redux Toolkit, React Reanimated y módulos nativos) para construir interfaces fluidas y accesibles en web, iOS y Android. He publicado cuatro aplicaciones móviles en ambas plataformas, gestionando todo el ciclo: diseño, desarrollo, pruebas, despliegue y métricas post-lanzamiento.</p>
-        <p>En el backend me muevo con Node.js + TypeScript y Python, orquestando microservicios en GCP y Firebase, integrando bases de datos SQL y NoSQL, y automatizando despliegues con contenedores y pipelines CI/CD. También disfruto meter mano en Kotlin, Objective-C y herramientas como Xcode y Android Studio para desarrollar o integrar funcionalidades nativas cuando el rendimiento lo exige.</p>
-        <p>La inteligencia artificial es mi parque de diversiones actual: experimento con modelos locales en LM Studio, uso Gemma 3 para prototipos de IA generativa y combino Whisper y Coqui TTS para procesamiento de voz en tiempo real. Estos proyectos, y otros que exploran visión por computador y chatbots, estarán visibles en la sección de Proyectos.</p>
-        <p>Más allá de las tecnologías, lo que me define es la curiosidad, la obsesión por el detalle y el deseo constante de aprender y compartir conocimiento. Mi meta es seguir construyendo productos que enamoren a los usuarios y desafíen mis límites como desarrollador y como ser humano.</p>
+        <div className="postics-container">
+          {notes.map((note, idx) => (
+            <div
+              key={note.title}
+              className="postic"
+              style={{ transform: `rotate(${rotations[idx]}deg)` }}
+            >
+              <h3>{note.title}</h3>
+              {note.content.map((line, i) => (
+                <p key={i}>{line}</p>
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- redesign experience section with sticky note-style posts
- show notes rotated randomly for a casual look

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e216be90483279cbea75d521a6b7c