### PR TITLE
Limit posts per row

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -24,6 +24,9 @@
   justify-content: center;
   gap: 2rem;
   margin-top: 2rem;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .postic {


### PR DESCRIPTION
## Summary
- limit experience posts container width so only up to three cards fit per row

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e22ad2964832785dd51f7afd43f4d