### PR TITLE
Adjust contact sidebar and experience style

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Sebastián Avilés</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -95,6 +95,11 @@
   align-items: center;
 }
 
+.sidebar-bottom .contact-link {
+  width: auto;
+  justify-content: center;
+}
+
 
 .pages {
   padding-left: 14%;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,15 +71,7 @@ function App() {
           ))}
         </div>
         <div className="sidebar-bottom">
-          <a
-            href="https://wa.me/573023350784"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <span className="icon">💬</span>
-            <span className="label">WhatsApp</span>
-          </a>
-          <a href="mailto:juansebastian3g@gmail.com">
+          <a href="mailto:juansebastian3g@gmail.com" className="contact-link">
             <span className="icon">📧</span>
             <span className="label">Correo</span>
           </a>

--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -30,7 +30,7 @@
 }
 
 .postic {
-  background: #fef3a0;
+  background: #e0e0e0;
   color: #333;
   padding: 1rem;
   width: 220px;

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -45,6 +45,7 @@
   align-items: center;
   justify-content: center;
   opacity: 0;
+  height: 320px;
 }
 
 .tools {


### PR DESCRIPTION
## Summary
- update page title to Sebastián Avilés
- tone down the experience post-it background
- keep only the email link in the sidebar and center it
- ensure hero animation elements share the same height

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e29a7b9108327907b9368b32645cb