### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -180,3 +180,21 @@
   justify-content: center;
   font-size: 1.5rem;
 }
+
+@media (max-width: 768px) {
+  .hero-banner {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .hero-left,
+  .hero-right {
+    flex: none;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .hero-right {
+    margin-top: 2rem;
+  }
+}

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -123,3 +123,22 @@
   from { transform: translateY(20px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
 }
+
+@media (max-width: 768px) {
+  .project-item {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .project-info,
+  .project-image {
+    flex: none;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .project-image {
+    order: -1;
+    margin-bottom: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- move hero animations below content on narrow screens
- stack project card image above info on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e32d888388327a98531b4cb12417d