### PR TITLE
Add resume button and adjust project card sizes

### DIFF
--- a/public/cv.pdf
+++ b/public/cv.pdf
@@ -1,0 +1,20 @@
+%PDF-1.4
+1 0 obj <</Type /Catalog /Pages 2 0 R>> endobj
+2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>> endobj
+3 0 obj <</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R>> endobj
+4 0 obj <</Length 55>>stream
+BT /F1 24 Tf 100 700 Td (Hoja de Vida) Tj ET
+endstream endobj
+5 0 obj <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>> endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000116 00000 n 
+0000000216 00000 n 
+0000000329 00000 n 
+trailer <</Size 6 /Root 1 0 R>>
+startxref
+395
+%%EOF

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -181,6 +181,27 @@
   font-size: 1.5rem;
 }
 
+.resume-download {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.resume-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: #646cff;
+  color: #fff;
+  border-radius: 9999px;
+  text-decoration: none;
+  transition: background 0.3s;
+}
+
+.resume-button:hover {
+  background: #535bf2;
+}
+
 @media (max-width: 768px) {
   .hero-banner {
     flex-direction: column;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -100,6 +100,11 @@ function Hero() {
           </div>
         </div>
       </div>
+      <div className="resume-download">
+        <a href="/cv.pdf" className="resume-button" download>
+          Descargar hoja de vida
+        </a>
+      </div>
     </div>
   )
 }

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -16,9 +16,9 @@
   background: none;
   padding: 1.5rem;
   border-radius: 8px;
-  max-width: 880px;
+  max-width: 968px;
   width: 100%;
-  height: 80vh;
+  height: 92vh;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- grow project cards so the list area shows more items and make them wider
- add a download button for the résumé under the hero animations
- provide placeholder CV in `public`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e3456dd2483278bfcbe988907081a