### PR TITLE
Fix resume button position

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -2,6 +2,8 @@
   display: flex;
   height: 100vh;
   width: 100%;
+  position: relative;
+  overflow: visible;
 }
 
 .hero-left,
@@ -185,7 +187,9 @@
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-top: 2rem;
+  position: absolute;
+  bottom: -2rem;
+  left: 0;
 }
 
 .resume-button {
@@ -216,6 +220,12 @@
   }
 
   .hero-right {
+    margin-top: 2rem;
+  }
+
+  .resume-download {
+    position: static;
+    bottom: auto;
     margin-top: 2rem;
   }
 }


### PR DESCRIPTION
## Summary
- reposition resume button so it stays below the hero animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e371f19948327a41c5a0be547b071