### PR TITLE
Set TrailGrid as Hero background

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -11,6 +11,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  z-index: 1;
 }
 
 .hero-left {
@@ -188,6 +190,7 @@
   display: flex;
   justify-content: center;
   position: absolute;
+  z-index: 1;
   bottom: -2rem;
   left: 0;
 }

--- a/src/components/trailGrid/TrailGrid.css
+++ b/src/components/trailGrid/TrailGrid.css
@@ -1,11 +1,17 @@
+
 .trail-grid {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   display: grid;
   gap: 1px;                          /* línea divisoria entre celdas */
   background: #232323;               /* color de las “rayas” del grid */
+  z-index: 0;
 }
 
 .trail-cell {
-  background: #0d0d0d;               /* color base */
+  background: #242424;               /* color base ajustado al color de la card */
   transition: background 0.8s ease;  /* controla la duración del “desvanecido” */
 }
 


### PR DESCRIPTION
## Summary
- place the TrailGrid as absolute background in the Hero component
- tweak Hero elements to appear above the grid
- match TrailGrid cell color with page background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e39c60d1083279c756087a8e226c1