### PR TITLE
Swap sticky notes for marquee cards

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -22,30 +22,105 @@
   align-items: center;
 }
 
-.postics-container {
+.experience-marquee {
+  position: relative;
+  width: 100%;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 2rem;
-  margin-top: 2rem;
-  max-width: 80%;
+  overflow: hidden;
 }
 
-.postic {
-  background: #e0e0e0;
-  color: #333;
+.experience-marquee::before,
+.experience-marquee::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 25%;
+  pointer-events: none;
+}
+
+.experience-marquee::before {
+  left: 0;
+  background: linear-gradient(to right, #242424, transparent);
+}
+
+.experience-marquee::after {
+  right: 0;
+  background: linear-gradient(to left, #242424, transparent);
+}
+
+.marquee {
+  --duration: 20s;
+  --gap: 1rem;
+  display: flex;
+  overflow: hidden;
   padding: 1rem;
+  gap: var(--gap);
+}
+
+.marquee.vertical {
+  flex-direction: column;
+}
+
+.marquee.paused:hover .marquee-row {
+  animation-play-state: paused;
+}
+
+.marquee-row {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: space-around;
+  gap: var(--gap);
+  animation: marquee var(--duration) linear infinite;
+}
+
+.marquee-row.reverse {
+  animation-direction: reverse;
+}
+
+.marquee-row.vertical {
+  flex-direction: column;
+  animation-name: marquee-vertical;
+}
+
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes marquee-vertical {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+.experience-card {
+  position: relative;
   width: 260px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
-  transform-origin: center;
+  cursor: pointer;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  box-sizing: border-box;
 }
 
-.postic h3 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
+.experience-card h3 {
+  margin: 0 0 0.5rem;
 }
 
-.postic p {
+.experience-card p {
   margin: 0.25rem 0;
 }
 

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react'
+import { Marquee } from '../registry/magicui/marquee'
+import { cn } from '../lib/utils'
 import './Experience.css'
 
 const notes = [
@@ -52,9 +53,8 @@ const notes = [
 ]
 
 function Experience() {
-  const rotations = useMemo(() =>
-    notes.map(() => Math.random() * 30 - 15),
-  [])
+  const firstRow = notes.slice(0, Math.ceil(notes.length / 2))
+  const secondRow = notes.slice(Math.ceil(notes.length / 2))
 
   return (
     <div className="experience-section">
@@ -62,19 +62,31 @@ function Experience() {
         <h2 className="experience-title">
           <span className="experience-title-text">Experiencia</span>
         </h2>
-        <div className="postics-container">
-          {notes.map((note, idx) => (
-            <div
-              key={note.title}
-              className="postic"
-              style={{ transform: `rotate(${rotations[idx]}deg)` }}
-            >
-              <h3>{note.title}</h3>
-              {note.content.map((line, i) => (
-                <p key={i}>{line}</p>
-              ))}
-            </div>
-          ))}
+        <div className="experience-marquee">
+          <Marquee pauseOnHover className="marquee" repeat={2}>
+            {firstRow.map((note) => (
+              <figure key={note.title} className={cn('experience-card')}>
+                <figcaption>
+                  <h3>{note.title}</h3>
+                </figcaption>
+                {note.content.map((line, i) => (
+                  <p key={i}>{line}</p>
+                ))}
+              </figure>
+            ))}
+          </Marquee>
+          <Marquee pauseOnHover reverse className="marquee" repeat={2}>
+            {secondRow.map((note) => (
+              <figure key={note.title} className={cn('experience-card')}>
+                <figcaption>
+                  <h3>{note.title}</h3>
+                </figcaption>
+                {note.content.map((line, i) => (
+                  <p key={i}>{line}</p>
+                ))}
+              </figure>
+            ))}
+          </Marquee>
         </div>
       </div>
     </div>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/registry/magicui/marquee.jsx
+++ b/src/registry/magicui/marquee.jsx
@@ -1,0 +1,38 @@
+import { cn } from "../../lib/utils";
+
+export function Marquee({
+  className,
+  reverse = false,
+  pauseOnHover = false,
+  children,
+  vertical = false,
+  repeat = 4,
+  ...props
+}) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "marquee",
+        vertical && "vertical",
+        className,
+        pauseOnHover && "paused"
+      )}
+    >
+      {Array(repeat)
+        .fill(0)
+        .map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "marquee-row",
+              vertical && "vertical",
+              reverse && "reverse"
+            )}
+          >
+            {children}
+          </div>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace post-it style experience section with marquee cards
- add marquee component and `cn` utility
- adjust CSS for marquee animation and cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e41aacd008327a6f05420db1b4ed4