### PR TITLE
Add CodeDrift background to projects

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -24,6 +24,12 @@
   align-items: center;
   animation: fadeInUp 0.8s ease forwards;
   opacity: 0;
+  position: relative;
+}
+
+.projects-card > * {
+  position: relative;
+  z-index: 2;
 }
 
 .projects-nav-wrapper {

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import CodeDrift from './codeDrift/CodeDrift'
 import './Projects.css'
 
 const categories = ['Todos', 'FullStack', 'Frontend', 'Backend']
@@ -47,6 +48,7 @@ function Projects() {
   return (
     <div className="projects-section">
       <div className="projects-card">
+        <CodeDrift />
         <div className="projects-nav-wrapper">
           <nav className="projects-nav">
             {categories.map((cat) => (

--- a/src/components/codeDrift/CodeDrift.css
+++ b/src/components/codeDrift/CodeDrift.css
@@ -1,0 +1,27 @@
+.code-drift-wrapper {
+  position: absolute;
+  inset: 0;               /* cubre todo el hero */
+  overflow: hidden;
+  z-index: 1;             /* por detrás del contenido interactivo */
+  pointer-events: none;   /* no bloquea clics */
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #6b6b6b;         /* gris sutil; súbelo para más contraste */
+  opacity: 0.25;          /* transparencia global */
+}
+
+/* Cada línea de código que cruza */
+.code-drift-line {
+  position: absolute;
+  white-space: nowrap;
+  animation-name: drift-right;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+/* Animación: de -100vw → 100vw */
+@keyframes drift-right {
+  0%   { transform: translateX(-110vw); }
+  100% { transform: translateX(110vw); }
+}

--- a/src/components/codeDrift/CodeDrift.jsx
+++ b/src/components/codeDrift/CodeDrift.jsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import './CodeDrift.css';
+
+interface CodeDriftProps {
+  /** Nº de “hileras” de texto que cruzan la pantalla */
+  rows?: number;
+  /** Tiempo (s) que tarda cada hilera en cruzar */
+  baseDuration?: number;
+}
+
+export default function CodeDrift({ rows = 14, baseDuration = 20 }: CodeDriftProps) {
+  // Generamos un array con código aleatorio solo la primera vez
+  const snippets = useMemo(() => {
+    const samples = [
+      'const sum = (a,b) => a + b;',
+      'if (result === void 0) return;',
+      'for (let i=0;i<items.length;i++){ }',
+      'def hello(): print("Hello")',
+      'useEffect(()=>{},[])',
+      '#pragma GCC diagnostic',
+      'public class MyClass { }',
+      'SELECT * FROM users;',
+      'async function main() { await fetch() }',
+      'let _ = [].flatMap(decodeThought);',
+    ];
+    return Array.from({ length: rows }, () =>
+      Array.from({ length: 8 }, () => samples[Math.floor(Math.random() * samples.length)]).join('   ')
+    );
+  }, [rows]);
+
+  return (
+    <div className="code-drift-wrapper">
+      {snippets.map((snippet, i) => (
+        <span
+          key={i}
+          className="code-drift-line"
+          style={{
+            // Duración y desfase para que no vayan sincronizadas
+            animationDuration: `${baseDuration + (i % 5) * 2}s`,
+            animationDelay: `${-(i * 1.5)}s`,
+            top: `calc(${(i / rows) * 100}% - 0.5rem)`,
+          }}
+        >
+          {snippet}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `CodeDrift` component for animated code lines
- layer `CodeDrift` behind the project card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e43b4fa9c8327a52d64e619a42c28