### PR TITLE
Fix CodeDrift layering and typing animation

### DIFF
--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   overflow-y: auto;
   gap: 1rem;
+  position: relative; /* para posicionar CodeDrift */
 }
 
 .projects-card {

--- a/src/components/codeDrift/CodeDrift.css
+++ b/src/components/codeDrift/CodeDrift.css
@@ -1,30 +1,38 @@
 .code-drift-wrapper {
   position: absolute;
-  inset: 0;               /* cubre todo el hero */
+  inset: 0;               /* cubre toda la sección */
   overflow: hidden;
-  z-index: 1;             /* por detrás del contenido interactivo */
   pointer-events: none;   /* no bloquea clics */
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
   line-height: 1rem;
-  color: #6b6b6b;         /* gris sutil; súbelo para más contraste */
+  color: #6b6b6b;         /* gris sutil */
   opacity: 0.65;          /* transparencia global */
-  z-index: 1;
+  z-index: 0;             /* detrás del contenido */
 }
 
 /* Cada línea de código que cruza */
 .code-drift-line {
   position: absolute;
   white-space: nowrap;
-  animation-name: drift-right;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
+  overflow: hidden;
+  border-right: 2px solid #c7c7c7;
+  animation-name: drift-right, typing;
+  animation-timing-function: linear, steps(var(--line-len));
+  animation-duration: var(--drift-duration), 4s;
+  animation-delay: var(--drift-delay), var(--drift-delay);
+  animation-iteration-count: infinite, infinite;
   color: #184;
-  z-index: 1;
+  z-index: 0;
 }
 
 /* Animación: de -100vw → 100vw */
 @keyframes drift-right {
   0%   { transform: translateX(-110vw); z-index: 1; }
   100% { transform: translateX(110vw); z-index: 1; }
+}
+
+@keyframes typing {
+  from { width: 0; }
+  to { width: var(--line-len); }
 }

--- a/src/components/codeDrift/CodeDrift.jsx
+++ b/src/components/codeDrift/CodeDrift.jsx
@@ -30,8 +30,9 @@ export default function CodeDrift({ rows = 14, baseDuration = 20 }) {
           className="code-drift-line"
           style={{
             // Duración y desfase para que no vayan sincronizadas
-            animationDuration: `${baseDuration + (i % 5) * 2}s`,
-            animationDelay: `${-(i * 1.5)}s`,
+            '--line-len': `${snippet.length}ch`,
+            '--drift-duration': `${baseDuration + (i % 5) * 2}s`,
+            '--drift-delay': `${-(i * 1.5)}s`,
             top: `calc(${(i / rows) * 100}% - 0.5rem)`,
           }}
         >


### PR DESCRIPTION
## Summary
- keep CodeDrift behind project cards and filter bar
- animate code snippets with a typing effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e47b7bc1083279abe86cf50ff0073