### PR TITLE
Fix spacing for experience cards

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -63,7 +63,7 @@ function Experience() {
           <span className="experience-title-text">Experiencia</span>
         </h2>
         <div className="experience-marquee">
-          <Marquee pauseOnHover className="marquee" repeat={2}>
+          <Marquee pauseOnHover className="marquee" repeat={20}>
             {firstRow.map((note) => (
               <figure key={note.title} className={cn('experience-card')}>
                 <figcaption>
@@ -75,7 +75,7 @@ function Experience() {
               </figure>
             ))}
           </Marquee>
-          <Marquee pauseOnHover reverse className="marquee" repeat={2}>
+          <Marquee pauseOnHover reverse className="marquee" repeat={20}>
             {secondRow.map((note) => (
               <figure key={note.title} className={cn('experience-card')}>
                 <figcaption>


### PR DESCRIPTION
## Summary
- extend repeated card count in Experience marquee so the scrolling loop never leaves blank gaps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4ed49d848327ae333ac2ce3ea0d4