### PR TITLE
Fix navigation layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,22 @@
   z-index: 10;
 }
 
+.sidebar-top {
+  position: absolute;
+  top: 1rem;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profile-photo {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+}
+
 .sidebar:hover {
   width: 150px;
   align-items: flex-start;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import {
   House,
   Briefcase,
   Folder,
-  Lightbulb,
   Mail,
 } from 'lucide-react'
 import './App.css'
@@ -15,7 +14,6 @@ const sections = [
   { name: 'inicio', label: 'Inicio', icon: House },
   { name: 'experiencia', label: 'Experiencia', icon: Briefcase },
   { name: 'proyectos', label: 'Proyectos', icon: Folder },
-  { name: 'inspiracion', label: 'Inspiracion', icon: Lightbulb },
   { name: 'contacto', label: 'Contacto', icon: Mail },
 ]
 
@@ -56,6 +54,14 @@ function App() {
   return (
     <div className="app">
       <nav className="sidebar">
+        <div className="sidebar-top">
+          <button className="profile-button">
+            <span className="icon">
+              <img src="/vite.svg" alt="Perfil" className="profile-photo" />
+            </span>
+            <span className="label">Perfil</span>
+          </button>
+        </div>
         <div className="sidebar-menu">
           {sections.map(({ name, label, icon: Icon }, idx) => (
             <button

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -36,6 +36,9 @@
   justify-content: center;
   align-items: center;
   z-index: 2;
+  position: sticky;
+  top: 0;
+  background: #222;
 }
 
 .projects-nav {

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import CodeDrift from './codeDrift/CodeDrift'
 import './Projects.css'
 
@@ -41,12 +41,17 @@ const projects = [
 
 function Projects() {
   const [filter, setFilter] = useState('Todos')
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    containerRef.current?.scrollTo({ top: 0 })
+  }, [filter])
 
   const filtered =
     filter === 'Todos' ? projects : projects.filter((p) => p.category === filter)
 
   return (
-    <div className="projects-section">
+    <div className="projects-section" ref={containerRef}>
       <CodeDrift />
       <div className="projects-card">
         


### PR DESCRIPTION
## Summary
- remove Inspiracion section
- add profile button at top of sidebar
- keep nav inside projects section sticky
- reset scroll position when filtering projects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e56576fa08327a71029ff0e4c09d1