### PR TITLE
Add repo icon & fix projects navbar

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -6,6 +6,15 @@
   overflow: visible;
 }
 
+.repo-icon {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 4;
+  pointer-events: auto;
+  color: inherit;
+}
+
 .hero-left {
   align-self: center;
 }

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Github, Linkedin } from 'lucide-react'
+import { Github, Linkedin, Terminal } from 'lucide-react'
 import TrailGrid from "./trailGrid/TrailGrid"
 import {
   SiReact,
@@ -42,6 +42,14 @@ function Hero() {
   return (
     <div className="hero-banner">
       <TrailGrid rows={34} cols={42} />
+      <a
+        href="https://github.com/SbtnAvls/me"
+        className="repo-icon"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Terminal size={24} />
+      </a>
 
       <div className="hero-left">
         {/* <EyesAnimation /> */}

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -1,6 +1,6 @@
 .projects-section {
   width: 100%;
-  height: 130vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -13,15 +13,17 @@
 }
 
 .projects-card {
-  position: relative;     /* ya lo tienes ✅  */
-  overflow: hidden;       /* 👈 evita que el rain desborde */
-  /* …resto de reglas… */
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  width: 50vw;
+  height: 100%;
 }
 
 .projects-card > * {
   position: relative;
-  width: 50vw;
-  height: 100vh;
+  width: 100%;
   z-index: 2;
 }
 
@@ -31,7 +33,6 @@
 }
 
 .projects-nav-wrapper {
-  height: 20%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -39,6 +40,7 @@
   position: sticky;
   top: 0;
   background: #222;
+  padding: 1rem 0;
 }
 
 .projects-nav {
@@ -76,8 +78,8 @@
   display: flex;
   flex-direction: column;
   gap: calc(1rem + 2%);
-  height: 80%;
-  overflow-y: scroll;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .project-item h3 {


### PR DESCRIPTION
## Summary
- add a top-right repo icon on the hero card linking to GitHub
- keep Projects navbar static when filtering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e59586adc8327baa8ea320fbb0e68