### PR TITLE
Make sidebar top-fixed on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -158,3 +158,55 @@
   opacity: 1;
   transform: translateY(0);
 }
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+    width: 100%;
+    height: 60px;
+    flex-direction: row;
+    padding: 0 1rem;
+  }
+
+  .sidebar:hover {
+    width: 100%;
+    align-items: center;
+  }
+
+  .sidebar-top,
+  .sidebar-bottom {
+    position: static;
+  }
+
+  .sidebar-menu {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .sidebar button .label,
+  .sidebar a .label,
+  .sidebar:hover button .label,
+  .sidebar:hover a .label {
+    max-width: 100px;
+    opacity: 1;
+  }
+
+  .sidebar-bottom {
+    display: none;
+  }
+
+  .pages {
+    margin: 60px 0 0 0;
+    width: 100%;
+  }
+
+  .sidebar:hover ~ .pages {
+    margin: 60px 0 0 0;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- move sidebar to the top of the screen on narrow viewports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e63556d8883279599a6c861ec830d