### PR TITLE
Fix mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -192,8 +192,7 @@
   .sidebar a .label,
   .sidebar:hover button .label,
   .sidebar:hover a .label {
-    max-width: 100px;
-    opacity: 1;
+    display: none;
   }
 
   .sidebar-bottom {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -230,13 +230,11 @@
 @media (max-width: 768px) {
   .hero-banner {
     display: flex;
-    height: 100vh;
+    flex-direction: column;
     width: 100%;
     position: relative;
     overflow: hidden;
-  
-    /* 🆕 centra a hero-left y hero-right en el eje vertical */
-    align-items: center;             /* ← la clave */
+    align-items: center;
   }
 
   .hero-left,
@@ -244,6 +242,13 @@
   .resume-download {
     position: relative;
     z-index: 2;            /* cualquier valor >0 sirve */
+  }
+
+  .hero-left,
+  .hero-right {
+    flex: 0 0 auto;
+    max-width: 100%;
+    width: 100%;
   }
 
   .hero-right {


### PR DESCRIPTION
## Summary
- hide sidebar text labels on small screens
- stack hero sections vertically on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e64e076fc8327a92695559fbafe2c