### PR TITLE
Fix sidebar width on mobile and adjust resume button position

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,6 +19,7 @@
   display: flex;
   flex-direction: column;
   padding: 1rem;
+  box-sizing: border-box;
   transition: width 0.3s;
   align-items: center;
   z-index: 10;
@@ -170,6 +171,7 @@
     height: 60px;
     flex-direction: row;
     padding: 0 1rem;
+    box-sizing: border-box;
   }
 
   .sidebar:hover {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -209,7 +209,7 @@
   justify-content: center;
   position: absolute;
   z-index: 3;
-  bottom: 22rem;
+  bottom: 2rem;
   left: 0;
 }
 
@@ -268,7 +268,7 @@
   .resume-download {
     position: static;
     bottom: auto;
-    margin-top: 20%;
+    margin-top: 1rem;
   }
 
   .hero-left h1 {


### PR DESCRIPTION
## Summary
- ensure sidebar uses border-box sizing to prevent overflow
- position resume download button under animation box

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6a3d90ac8327981c4c2887cc73b5