### PR TITLE
Fix mobile layout for sidebar and experience carousel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -187,7 +187,8 @@
   .sidebar-menu {
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 1rem;
     width: 100%;
   }
 

--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -22,6 +22,12 @@
   align-items: center;
 }
 
+@media (max-width: 768px) {
+  .experience-wrapper {
+    max-width: 100%;
+  }
+}
+
 .experience-marquee {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- center navigation icons on mobile sidebar
- make Experience carousel full-width on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6bbff1b88327b0bafbe81951cf13