### PR TITLE
Fix sidebar overflow and mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,15 +25,6 @@
   z-index: 10;
 }
 
-.sidebar-top {
-  position: absolute;
-  top: 1rem;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
 
 .profile-photo {
   width: 1.5rem;
@@ -42,7 +33,7 @@
 }
 
 .sidebar:hover {
-  width: 150px;
+  width: 200px;
   align-items: flex-start;
 }
 
@@ -134,8 +125,8 @@
 }
 
 .sidebar:hover ~ .pages {
-  margin-left: 150px;
-  width: calc(100% - 150px);
+  margin-left: 200px;
+  width: calc(100% - 200px);
 }
 
 .page {
@@ -179,7 +170,6 @@
     align-items: center;
   }
 
-  .sidebar-top,
   .sidebar-bottom {
     position: static;
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,15 +55,13 @@ function App() {
   return (
     <div className="app">
       <nav className="sidebar">
-        <div className="sidebar-top">
+        <div className="sidebar-menu">
           <button className="profile-button">
             <span className="icon">
               <img src="/vite.svg" alt="Perfil" className="profile-photo" />
             </span>
             <span className="label">Perfil</span>
           </button>
-        </div>
-        <div className="sidebar-menu">
           {sections.map(({ name, label, icon: Icon }, idx) => (
             <button
               key={name}

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -254,6 +254,10 @@
   .hero-right {
     margin-top: 2rem;
     min-height: 380px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
   }
 
   .tools,


### PR DESCRIPTION
## Summary
- restructure sidebar markup to include profile button in the main menu
- expand sidebar hover width to avoid overflow and update page offset
- remove unused sidebar-top styles
- tweak mobile sidebar styles and hero mobile layout so resume button sits below the animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6e34ba1483279a8b74869bfc6500