### PR TITLE
Fix profile button placement

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,10 @@
   border-radius: 50%;
 }
 
+.profile-button {
+  margin-bottom: 1rem;
+}
+
 .sidebar:hover {
   width: 200px;
   align-items: flex-start;
@@ -46,8 +50,9 @@
   flex-direction: column;
   gap: 1rem;
   flex: 1;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
+  margin-top: 1rem;
 }
 
 .sidebar button,
@@ -180,6 +185,10 @@
     justify-content: center;
     gap: 1rem;
     width: 100%;
+  }
+
+  .profile-button {
+    margin-bottom: 0;
   }
 
   .sidebar button .label,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,13 +55,13 @@ function App() {
   return (
     <div className="app">
       <nav className="sidebar">
+        <button className="profile-button">
+          <span className="icon">
+            <img src="/vite.svg" alt="Perfil" className="profile-photo" />
+          </span>
+          <span className="label">Perfil</span>
+        </button>
         <div className="sidebar-menu">
-          <button className="profile-button">
-            <span className="icon">
-              <img src="/vite.svg" alt="Perfil" className="profile-photo" />
-            </span>
-            <span className="label">Perfil</span>
-          </button>
           {sections.map(({ name, label, icon: Icon }, idx) => (
             <button
               key={name}


### PR DESCRIPTION
## Summary
- move profile button outside of the menu so it stays at the top of the sidebar
- adjust layout styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e74d9fe708327a3ba5d465b762701