### PR TITLE
Adjust sidebar layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,9 +50,8 @@
   flex-direction: column;
   gap: 1rem;
   flex: 1;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
-  margin-top: 1rem;
 }
 
 .sidebar button,


### PR DESCRIPTION
## Summary
- center icons inside the sidebar menu for desktop screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e76c220dc83279a38fb8642d675ec