### PR TITLE
Improve code modal closing behaviour

### DIFF
--- a/src/components/CodeModal.jsx
+++ b/src/components/CodeModal.jsx
@@ -6,10 +6,17 @@ export default function CodeModal({ open, onClose, code }) {
     if (!open) return
     const prev = document.body.style.overflow
     document.body.style.overflow = 'hidden'
+
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+
     return () => {
       document.body.style.overflow = prev
+      window.removeEventListener('keydown', handleKey)
     }
-  }, [open])
+  }, [open, onClose])
   if (!open) return null
   return (
     <div className="code-modal-overlay" onClick={onClose}>


### PR DESCRIPTION
## Summary
- allow closing the code modal with Escape key

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685e7e8b1b288327a7ccf9868e24e13f