### PR TITLE
Fix hero resume button on small phones

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -233,7 +233,9 @@
     flex-direction: column;
     width: 100%;
     position: relative;
-    overflow: hidden;
+    height: auto;
+    min-height: 100vh;
+    overflow: visible;
     align-items: center;
   }
 


### PR DESCRIPTION
## Summary
- allow hero banner to grow taller on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea846b2a08327972dfe6f71c42244