### PR TITLE
feat: floating sidebar layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,9 +12,10 @@
 
 .sidebar {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
+  top: 50%;
+  left: 1rem;
+  height: 65vh;
+  transform: translateY(-50%);
   width: 60px;
   background: #333;
   color: #fff;
@@ -24,6 +25,7 @@
   box-sizing: border-box;
   transition: width 0.3s;
   align-items: center;
+  border-radius: 0.5rem;
   z-index: 10;
 }
 
@@ -117,8 +119,8 @@
 
 
 .pages {
-  margin-left: 60px;
-  width: calc(100% - 60px);
+  margin-left: calc(60px + 1rem);
+  width: calc(100% - 60px - 1rem);
   height: 100vh;
   overflow-y: auto;
   transition: margin-left 0.3s, width 0.3s;
@@ -131,8 +133,8 @@
 }
 
 .sidebar:hover ~ .pages {
-  margin-left: 200px;
-  width: calc(100% - 200px);
+  margin-left: calc(200px + 1rem);
+  width: calc(100% - 200px - 1rem);
 }
 
 .page {
@@ -169,6 +171,8 @@
     flex-direction: row;
     padding: 0 1rem;
     box-sizing: border-box;
+    transform: none;
+    border-radius: 0;
   }
 
   .sidebar:hover {


### PR DESCRIPTION
## Summary
- make sidebar float on the left with a 65vh height and rounded corners
- offset page content to account for new sidebar position
- ensure mobile layout resets sidebar position

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686074daa8548327a00ca4239c12172d