### PR TITLE
Adjust experience carousel layout on mobile

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -26,6 +26,13 @@
   .experience-wrapper {
     max-width: 100%;
   }
+  .experience-section {
+    padding: 2rem 0;
+  }
+  .experience-marquee {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+  }
 }
 
 .experience-marquee {


### PR DESCRIPTION
## Summary
- ensure the Experience section fills the entire viewport width on small screens
- keep fade overlays on both edges of the carousel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6861a5d26e2c8327a28417a7b9f536e9