### PR TITLE
Set cards full width and fix sidebar overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -119,8 +119,8 @@
 
 
 .pages {
-  margin-left: calc(60px + 1rem);
-  width: calc(100% - 60px - 1rem);
+  margin-left: 0;
+  width: 100%;
   height: 100vh;
   overflow-y: auto;
   transition: margin-left 0.3s, width 0.3s;
@@ -133,8 +133,8 @@
 }
 
 .sidebar:hover ~ .pages {
-  margin-left: calc(200px + 1rem);
-  width: calc(100% - 200px - 1rem);
+  margin-left: 0;
+  width: 100%;
 }
 
 .page {

--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -119,7 +119,7 @@
 
 .experience-card {
   position: relative;
-  width: 260px;
+  width: 100%;
   cursor: pointer;
   overflow: hidden;
   border-radius: 12px;

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -17,7 +17,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  width: 50vw;
+  width: 100%;
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- prevent sidebar expansion from pushing page content
- let project card fill the entire page width
- make experience cards full width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a9e543ac8327b538bfa476df0c77