### PR TITLE
Improve Experience scroll and mobile layout

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -22,130 +22,26 @@
   align-items: center;
 }
 
+.experience-scroll {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.experience-scroll::-webkit-scrollbar {
+  display: none;
+}
+
 @media (max-width: 768px) {
   .experience-wrapper {
     max-width: 100%;
   }
   .experience-section {
     padding: 2rem 0;
-  }
-  .experience-marquee {
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-  }
-}
-
-.experience-marquee {
-  position: relative;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.experience-marquee::before,
-.experience-marquee::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 15%;
-  pointer-events: none;
-}
-
-.experience-marquee::before {
-  left: 0;
-  background: linear-gradient(to right, #242424, transparent);
-}
-
-.experience-marquee::after {
-  right: 0;
-  background: linear-gradient(to left, #242424, transparent);
-}
-
-
-
-
-
-
-.experience-marquee-2::before,
-.experience-marquee-2::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 15%;
-  pointer-events: none;
-}
-
-.experience-marquee-2::before {
-  right: 0;
-  background: linear-gradient(to left, #242424, transparent);
-}
-
-.experience-marquee-2::after {
-  left: 0;
-  background: linear-gradient(to right, #242424, transparent);
-}
-
-.marquee {
-  --duration: 20s;
-  --gap: 1rem;
-  display: flex;
-  overflow: hidden;
-  padding: 1rem;
-  gap: var(--gap);
-  overflow: scroll;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.marquee::-webkit-scrollbar {
-  display: none;
-}
-
-.marquee.vertical {
-  flex-direction: column;
-}
-
-.marquee.paused:hover .marquee-row {
-  animation-play-state: paused;
-}
-
-.marquee-row {
-  display: flex;
-  flex-shrink: 0;
-  justify-content: space-around;
-  gap: var(--gap);
-  animation: marquee var(--duration) linear infinite;
-}
-
-.marquee-row.reverse {
-  animation-direction: reverse;
-}
-
-.marquee-row.vertical {
-  flex-direction: column;
-  animation-name: marquee-vertical;
-}
-
-@keyframes marquee {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-100%);
-  }
-}
-
-@keyframes marquee-vertical {
-  from {
-    transform: translateY(0);
-  }
-  to {
-    transform: translateY(-100%);
   }
 }
 
@@ -159,6 +55,8 @@
   background: rgba(255, 255, 255, 0.05);
   padding: 1rem;
   box-sizing: border-box;
+  flex: 0 0 auto;
+  scroll-snap-align: center;
 }
 
 .experience-card h3 {

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,4 +1,3 @@
-import { Marquee } from '../registry/magicui/marquee'
 import { cn } from '../lib/utils'
 import './Experience.css'
 
@@ -53,42 +52,23 @@ const notes = [
 ]
 
 function Experience() {
-  const firstRow = notes.slice(0, Math.ceil(notes.length / 2))
-  const secondRow = notes.slice(Math.ceil(notes.length / 2))
-
   return (
     <div className="experience-section">
       <div className="experience-wrapper">
         <h2 className="experience-title">
           <span className="experience-title-text">Experiencia</span>
         </h2>
-        <div className="experience-marquee">
-          <div className='experience-marquee-2'>
-            <Marquee pauseOnHover className="marquee" repeat={20}>
-              {firstRow.map((note) => (
-                <figure key={note.title} className={cn('experience-card')}>
-                  <figcaption>
-                    <h3>{note.title}</h3>
-                  </figcaption>
-                  {note.content.map((line, i) => (
-                    <p key={i}>{line}</p>
-                  ))}
-                </figure>
+        <div className="experience-scroll">
+          {notes.map((note) => (
+            <figure key={note.title} className={cn('experience-card')}>
+              <figcaption>
+                <h3>{note.title}</h3>
+              </figcaption>
+              {note.content.map((line, i) => (
+                <p key={i}>{line}</p>
               ))}
-            </Marquee>
-            <Marquee pauseOnHover reverse className="marquee" repeat={20}>
-              {secondRow.map((note) => (
-                <figure key={note.title} className={cn('experience-card')}>
-                  <figcaption>
-                    <h3>{note.title}</h3>
-                  </figcaption>
-                  {note.content.map((line, i) => (
-                    <p key={i}>{line}</p>
-                  ))}
-                </figure>
-              ))}
-            </Marquee>
-          </div>
+            </figure>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -238,6 +238,7 @@
     min-height: 100vh;
     overflow: visible;
     align-items: center;
+    padding-left: 0;
   }
 
   .hero-left,


### PR DESCRIPTION
## Summary
- replace marquee with horizontally scrollable cards
- remove unused marquee styles and add scroll styles
- center hero section on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6861e55a887883279f411718d5dc1439