### PR TITLE
Fix resume download button overlapping

### DIFF
--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -209,7 +209,7 @@
   display: flex;
   justify-content: center;
   position: absolute;
-  z-index: 3;
+  z-index: 10;      /* keep above following sections */
   bottom: 2rem;
   left: 0;
 }
@@ -245,7 +245,7 @@
   .hero-right,
   .resume-download {
     position: relative;
-    z-index: 2;            /* cualquier valor >0 sirve */
+    z-index: 10;           /* keep interactive elements on top */
   }
 
   .hero-left,


### PR DESCRIPTION
## Summary
- raise `z-index` on the resume download section so the button stays above following sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863f33486548327ad6d9aa4799afa87